### PR TITLE
Fixed errors when env var is not valid

### DIFF
--- a/src/builtin_cd.c
+++ b/src/builtin_cd.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   builtin_cd.c                                       :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: coder <coder@student.42.fr>                +#+  +:+       +#+        */
+/*   By: afaustin <afaustin@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/03/16 17:46:31 by adrianofaus       #+#    #+#             */
-/*   Updated: 2022/04/22 19:07:48 by coder            ###   ########.fr       */
+/*   Updated: 2022/04/22 23:29:28 by afaustin         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -76,21 +76,24 @@ void	builtin_cd(t_list *cmd_lst)
 {
 	char	*path;
 
-	if (cmd_lst->next)
-		path = (char *) cmd_lst->next->content;
-	if (cmd_lst->next && cmd_lst->next->next != NULL)
+	if (cmd_lst->next && cmd_lst->next->content)
 	{
-		g_tudao.exit.msg = \
-		ft_strdup("minishell: cd: too many arguments");
-		g_tudao.exit.code = EXIT_FAILURE;
-		return ;
+		path = (char *) cmd_lst->next->content;
+		if (cmd_lst->next && cmd_lst->next->next != NULL)
+		{
+			g_tudao.exit.msg = \
+			ft_strdup("minishell: cd: too many arguments");
+			g_tudao.exit.code = EXIT_FAILURE;
+			return ;
+		}
+		else if (cmd_lst->next == NULL
+			|| (ft_strncmp(path, "", 1) == 0)
+			|| (ft_strncmp(path, "~", 2) == 0))
+			go_to_pattern("HOME");
+		else if (ft_strncmp(path, "-", 2) == 0)
+			go_to_pattern("OLDPWD");
+		else
+			go_to_path(path);
 	}
-	else if (cmd_lst->next == NULL
-		|| (ft_strncmp(path, "", 1) == 0)
-		|| (ft_strncmp(path, "~", 2) == 0))
-		go_to_pattern("HOME");
-	else if (ft_strncmp(path, "-", 2) == 0)
-		go_to_pattern("OLDPWD");
-	else
-		go_to_path(path);
+	g_tudao.exit.code = 0;
 }

--- a/src/builtin_echo.c
+++ b/src/builtin_echo.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   builtin_echo.c                                     :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: coder <coder@student.42.fr>                +#+  +:+       +#+        */
+/*   By: afaustin <afaustin@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/03/21 17:15:44 by adrianofaus       #+#    #+#             */
-/*   Updated: 2022/04/22 19:07:48 by coder            ###   ########.fr       */
+/*   Updated: 2022/04/23 00:25:01 by afaustin         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,22 +19,22 @@ void	builtin_echo(t_list *lst)
 
 	pivot = lst->next;
 	option = 0;
-	if (pivot != NULL && !ft_strncmp((char *)pivot->content, "-n", 3))
+	if (pivot != NULL && pivot->content != NULL)
 	{
-		option = 1;
-		pivot = pivot->next;
-	}
-	while (pivot != NULL)
-	{
-		if ((pivot->next != NULL && !option) || option == 1)
+		if (!ft_strncmp((char *)pivot->content, "-n", 3))
+		{
+			option = 1;
+			pivot = pivot->next;
+		}
+		while (pivot != NULL)
 		{
 			ft_putstr_fd((char *) pivot->content, 1);
 			if (pivot->next != NULL)
 				ft_putchar_fd(' ', 1);
+			pivot = pivot->next;
 		}
-		else
-			ft_putendl_fd((char *) pivot->content, 1);
-		pivot = pivot->next;
 	}
+	if (!option)
+		ft_putchar_fd('\n', 1);
 	g_tudao.exit.code = 0;
 }


### PR DESCRIPTION
Add protection for function cd and echo.
What was changed -> Before getting the content from an env_variable we are checking if the content exists.

Fixed #105 
```
adrianofaus@DESKTOP-OBKD90Q:~/workspace/Minishell-42sp$ make valgrind
cd ./libs/libft && make
make[1]: Entering directory '/home/adrianofaus/workspace/Minishell-42sp/libs/libft'
make[1]: Leaving directory '/home/adrianofaus/workspace/Minishell-42sp/libs/libft'
mkdir -p ./obj/
valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes --quiet --tool=memcheck --suppressions=readline.supp --keep-debuginfo=yes --track-fds=yes ./minishell
Hello World !
/home/adrianofaus/workspace/Minishell-42sp $ unset HOME
/home/adrianofaus/workspace/Minishell-42sp $ cd $HOME
/home/adrianofaus/workspace/Minishell-42sp $ echo $HOME

/home/adrianofaus/workspace/Minishell-42sp $ ==2069== FILE DESCRIPTORS: 1 open at exit.
==2069== Open file descriptor 19: /dev/ptmx
==2069==    <inherited from parent>
==2069== 
==2069== 

```

Fixed #104 
```
Hello World !
/home/adrianofaus/workspace/Minishell-42sp $ export TESTE1=batata
/home/adrianofaus/workspace/Minishell-42sp $ echo $TESTE1
batata
/home/adrianofaus/workspace/Minishell-42sp $ ==1794== FILE DESCRIPTORS: 1 open at exit.
==1794== Open file descriptor 19: /dev/ptmx
==1794==    <inherited from parent>
==1794== 
==1794== 
unset TESTE1
/home/adrianofaus/workspace/Minishell-42sp $ echo $TESTE1

/home/adrianofaus/workspace/Minishell-42sp $ ==1882== FILE DESCRIPTORS: 1 open at exit.
==1882== Open file descriptor 19: /dev/ptmx
==1882==    <inherited from parent>
==1882== 
==1882== 
```
